### PR TITLE
Oil rig power improvements

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -101,6 +101,8 @@ local function onEntityBuild(e)
     else
       local or_power = surface.create_entity{name = "or_power", position = pos, force = force}
       table.insert(global.or_generators, or_power)
+      or_power.fluidbox[1] = {name="steam", amount = 200, temperature=165}  -- Initial power for rig, more comes from PowerOilRig()
+      surface.create_entity{name = "or_power_electric", position = pos, force = force}
       surface.create_entity{name = "or_pole", position = pos, force = force}
       surface.create_entity{name = "or_radar", position = pos, force = force}
     end
@@ -255,6 +257,10 @@ local function OnDeleted(e)
     elseif entity.name == "oil_rig" then
       local pos = entity.position
       local or_inv = entity.surface.find_entities_filtered{area={{pos.x-4, pos.y-4},{pos.x+4, pos.y+4}}, name="or_power"}
+      for i = 1, #or_inv do
+        or_inv[i].destroy()
+      end
+      or_inv = entity.surface.find_entities_filtered{area={{pos.x-4, pos.y-4},{pos.x+4, pos.y+4}}, name="or_power_electric"}
       for i = 1, #or_inv do
         or_inv[i].destroy()
       end
@@ -545,8 +551,13 @@ local function config_changed(changed_data)
       if global.or_generators ~= nil then
         for i, generator in pairs(global.or_generators) do
           if generator.valid then
-            local oil_rig = generator.surface.find_entity("oil_rig", generator.position)
-            generator.teleport(oil_rig.position)
+            local surface = generator.surface
+            local oil_rig = surface.find_entity("oil_rig", generator.position)
+            local position = oil_rig.position
+            generator.teleport(position)
+
+            -- Add new power entity
+            surface.create_entity{name = "or_power_electric", position = position, force = oil_rig.force}
           end
         end
       end

--- a/control.lua
+++ b/control.lua
@@ -527,44 +527,6 @@ local function init()
   init_events()
 end
 
-local function config_changed(changed_data)
-  local mod_changes = changed_data.mod_changes
-  local old_version
-  if mod_changes and mod_changes["cargo-ships"] and mod_changes["cargo-ships"]["old_version"] then
-    old_version = mod_changes["cargo-ships"]["old_version"]
-  else
-    return
-  end
-
-  log("Coming from old version: " .. old_version)
-  old_version = util.split(old_version, ".")
-  for i=1, #old_version do
-    old_version[i] = tonumber(old_version[i])
-  end
-
-  if old_version[1] == 0 then
-    if old_version[2] < 2 then
-      -- Pre 0.2.0
-
-      -- Teleport power entities to center of oil rigs since previously they didn't have
-      -- placeable-off-grid flag so weren't centered
-      if global.or_generators ~= nil then
-        for i, generator in pairs(global.or_generators) do
-          if generator.valid then
-            local surface = generator.surface
-            local oil_rig = surface.find_entity("oil_rig", generator.position)
-            local position = oil_rig.position
-            generator.teleport(position)
-
-            -- Add new power entity
-            surface.create_entity{name = "or_power_electric", position = position, force = oil_rig.force}
-          end
-        end
-      end
-    end
-  end
-end
-
 local function onTick(e)
   checkPlacement()
   ManageBridges(e)
@@ -591,10 +553,9 @@ script.on_init(function()
   log("cargo ships on_init")
   init()
   end)
-script.on_configuration_changed(function(changed_data)
+script.on_configuration_changed(function()
   log("cargo ships on_configuration_changed")
   init()
-  config_changed(changed_data)
   end)
 script.on_event(defines.events.on_runtime_mod_setting_changed, onModSettingsChanged)
 

--- a/control.lua
+++ b/control.lua
@@ -521,6 +521,39 @@ local function init()
   init_events()
 end
 
+local function config_changed(changed_data)
+  local mod_changes = changed_data.mod_changes
+  local old_version
+  if mod_changes and mod_changes["cargo-ships"] and mod_changes["cargo-ships"]["old_version"] then
+    old_version = mod_changes["cargo-ships"]["old_version"]
+  else
+    return
+  end
+
+  log("Coming from old version: " .. old_version)
+  old_version = util.split(old_version, ".")
+  for i=1, #old_version do
+    old_version[i] = tonumber(old_version[i])
+  end
+
+  if old_version[1] == 0 then
+    if old_version[2] < 2 then
+      -- Pre 0.2.0
+
+      -- Teleport power entities to center of oil rigs since previously they didn't have
+      -- placeable-off-grid flag so weren't centered
+      if global.or_generators ~= nil then
+        for i, generator in pairs(global.or_generators) do
+          if generator.valid then
+            local oil_rig = generator.surface.find_entity("oil_rig", generator.position)
+            generator.teleport(oil_rig.position)
+          end
+        end
+      end
+    end
+  end
+end
+
 local function onTick(e)
   checkPlacement()
   ManageBridges(e)
@@ -547,9 +580,10 @@ script.on_init(function()
   log("cargo ships on_init")
   init()
   end)
-script.on_configuration_changed(function()
-  log("cargo ships on_init")
+script.on_configuration_changed(function(changed_data)
+  log("cargo ships on_configuration_changed")
   init()
+  config_changed(changed_data)
   end)
 script.on_event(defines.events.on_runtime_mod_setting_changed, onModSettingsChanged)
 

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
   "name": "cargo-ships",
-  "version": "0.1.22",
+  "version": "0.2.0",
   "title": "Cargo Ships",
   "author": "rude_grass",
   "description": "Adds cargo ships, oil tankers, deep sea oil rigs and other ocean based content",

--- a/migrations/migrations-0-2-0.lua
+++ b/migrations/migrations-0-2-0.lua
@@ -1,0 +1,15 @@
+if global.or_generators ~= nil then
+  for i, generator in pairs(global.or_generators) do
+    if generator.valid then
+      -- Teleport power entities to center of oil rigs since previously they didn't have
+      -- placeable-off-grid flag so weren't centered
+      local surface = generator.surface
+      local oil_rig = surface.find_entity("oil_rig", generator.position)
+      local position = oil_rig.position
+      generator.teleport(position)
+
+      -- Add new power entity
+      surface.create_entity{name = "or_power_electric", position = position, force = oil_rig.force}
+    end
+  end
+end

--- a/prototypes/oil_rig.lua
+++ b/prototypes/oil_rig.lua
@@ -223,7 +223,7 @@ or_power.selection_box = nil
 or_power.collision_mask = {}
 or_power.fast_replaceable_group = nil
 or_power.next_upgrade = nil
-or_power.fluid_usage_per_tick = 1
+or_power.fluid_usage_per_tick = 0.1
 or_power.fluid_box = {
   base_area = 1,
   height = 1,
@@ -234,6 +234,7 @@ or_power.fluid_box = {
   filter = "steam",
   minimum_temperature = 100.0
 }
+or_power.energy_source.usage_priority = "primary-output"  -- Use all of this entity's power before using or_power_electric's
 or_power.horizontal_animation = emptypic
 or_power.vertical_animation = emptypic
 local smoke1shift = util.by_pixel(-85 + 2, -115 + 2)
@@ -245,7 +246,7 @@ or_power.smoke = {
     east_position = smoke1shift,
     south_position = smoke1shift,
     west_position = smoke1shift,
-    frequency = 0.5,
+    frequency = 0.25,
     starting_vertical_speed = 0.05,
     slow_down_factor = 1,
     starting_frame_deviation = 60
@@ -256,7 +257,7 @@ or_power.smoke = {
     east_position = smoke2shift,
     south_position = smoke2shift,
     west_position = smoke2shift,
-    frequency = 1,
+    frequency = 0.5,
     starting_vertical_speed = 0.05,
     slow_down_factor = 1,
     starting_frame_deviation = 60
@@ -264,6 +265,13 @@ or_power.smoke = {
 }
 or_power.water_reflection = nil
 or_power.working_sound = nil
+
+-- or_power's primary purpose is to create smoke when the oil rig is in use (and a little bit to power radar/pumps when not in use).
+-- Since the smoke is created proportional to the energy usage, we need this EEI to cover the high power demands e.g. when modules are used.
+local or_power_electric = table.deepcopy(data.raw["electric-energy-interface"]["hidden-electric-energy-interface"])
+or_power_electric.name = "or_power_electric"
+or_power_electric.energy_source.usage_priority = "secondary-output"
+or_power_electric.flags = {"not-blueprintable", "not-deconstructable", "placeable-off-grid"}
 
 local or_pole = table.deepcopy(data.raw["electric-pole"]["medium-electric-pole"])
 or_pole.name = "or_pole"
@@ -293,10 +301,10 @@ or_radar.fast_replaceable_group = nil
 or_radar.next_upgrade = nil
 or_radar.pictures = emptypic
 or_radar.max_distance_of_sector_revealed = 0
-or_radar.energy_usage = "50kW"
+or_radar.energy_usage = "30kW"
 or_radar.water_reflection = nil
 or_radar.working_sound = nil
 
-data:extend{oil_rig, or_power, or_pole, or_radar}
+data:extend{oil_rig, or_power, or_power_electric, or_pole, or_radar}
 
 end

--- a/prototypes/oil_rig.lua
+++ b/prototypes/oil_rig.lua
@@ -236,8 +236,8 @@ or_power.fluid_box = {
 }
 or_power.horizontal_animation = emptypic
 or_power.vertical_animation = emptypic
-local smoke1shift = util.by_pixel(-85 -14, -115 -14)
-local smoke2shift = util.by_pixel(53 -14, -167 -14)
+local smoke1shift = util.by_pixel(-85 + 2, -115 + 2)
+local smoke2shift = util.by_pixel(53 + 2, -167 + 2)
 or_power.smoke = {
   {
     name = "light-smoke",


### PR DESCRIPTION
#3 left the oil rig smoke offset because it is created by the power generator, which now spawns in a different place. This PR ensures that all rig power generators are teleported to the correct space and adjusts the smoke offset to compensate.

Secondly, there was a problem when modules were used to increase the power consumption of oil rigs too much, the power gen wouldn't keep up. Just increasing the power gen doesn't work because the smoke amount is proportional to the power usage, so it means that you don't get enough smoke. In this PR, I've relegated the power generator to primarily be for making smoke, and added a secondary-priority electric energy interface which can fill in as much power is needed.

Fully backwards compatible with old saves via a migration in `on_configuration_changed`.