### PR TITLE
Fixed Nullius Boats Breaking After Using Fuel

### DIFF
--- a/prototypes/ships.lua
+++ b/prototypes/ships.lua
@@ -715,11 +715,15 @@ cargo_ship_engine.drive_over_tie_trigger = nil
 cargo_ship_engine.corpse = nil
 
 
--- Makes boats use nullius fuels if that mod is installed
+-- Makes boats use nullius fuels if that mod is installed and make slots for the used fuels that nullius has
 if mods["nullius"] then
   indep_boat.burner.fuel_category = "vehicle"
   boat_engine.burner.fuel_category = "vehicle"
   cargo_ship_engine.burner.fuel_category = "vehicle"
+
+  indep_boat.burner.burnt_inventory_size = 1 * fuel_modifier
+  boat_engine.burner.burnt_inventory_size = 1 * fuel_modifier
+  cargo_ship_engine.burner.burnt_inventory_size = 2 * fuel_modifier
 end
 
 


### PR DESCRIPTION
So, apperently the Nullius fuels give a burnt result like: hydrogen canister -> water canister, so soon as the boat used up the fuel, it stopped because there was no place for the burnt fuel to go and yeah. I didn't realize that when I was testing, because you need to drive until the fuel gets burnt up before anything bad happens, but now I reached the point where I got the boats in my own playthrough and realized that.... Also I don't know why this pull request contains the fact that I synced the fork after you merged that other pull request, but I hope it doesn't matter.