### PR TITLE
Prevent reconnect recursion while mining ships

### DIFF
--- a/logic/ship_placement.lua
+++ b/logic/ship_placement.lua
@@ -283,6 +283,15 @@ function processPlacementQueue()
   RegisterPlacementOnTick()
 end
 
+local function isEnginePendingRemoval(engine)
+  if engine.to_be_deconstructed() then return true end
+  -- Player mining queues the engine for removal on the next tick.
+  for _, entry in pairs(storage.check_placement_queue) do
+    if entry.entity == engine and entry.player and entry.undo_index then return true end
+  end
+  return false
+end
+
 -- Disconnects/reconnects rolling stocks if they get wrongly connected/disconnected
 function OnTrainCreated(event)
   local contains_ship_engine = false
@@ -303,6 +312,12 @@ function OnTrainCreated(event)
   if #parts == 1 then
     -- reconnect!
     local engine = parts[1]
+    -- Removing the body splits the two-carriage train, so this handler runs for
+    -- the lone engine. Reconnecting an engine pending removal can couple it to a
+    -- nearby ship; overconnection repair disconnects it and calls this handler again.
+    if isEnginePendingRemoval(engine) then
+      return
+    end
     -- Connect engine in the direction of the expected ship body
     local connected = engine.connect_rolling_stock(storage.ship_engines[engine.name].coupled_ship)
     log("Tried connecting lonely "..engine.name.." at "..util.positiontostr(engine.position)..", result: "..tostring(connected))


### PR DESCRIPTION
Picking up a ship on a waterway near another ship could crash the mod with a infinite co-recursive stack overflow

```
The mod Cargo Ships (2.1.6) caused a non-recoverable error.
Please report this error to the mod author.

Error while running event cargo-ships::on_train_created (ID 83)
__cargo-ships__/logic/ship_placement.lua:289: C stack overflow
stack traceback:
	__cargo-ships__/logic/ship_placement.lua:289: in function <__cargo-ships__/logic/ship_placement.lua:287>
stack traceback:
	[C]: in function 'disconnect_rolling_stock'
	__cargo-ships__/logic/ship_placement.lua:323: in function <__cargo-ships__/logic/ship_placement.lua:287>
stack traceback:
	[C]: in function 'connect_rolling_stock'
	__cargo-ships__/logic/ship_placement.lua:307: in function <__cargo-ships__/logic/ship_placement.lua:287>
stack traceback:
	[C]: in function 'disconnect_rolling_stock'
	__cargo-ships__/logic/ship_placement.lua:323: in function <__cargo-ships__/logic/ship_placement.lua:287>
...
```

## The cause

Removing a ship body temporarily leaves its hidden engine as a one-carriage train. OnTrainCreated treated that engine as accidentally disconnected and attempted to reconnect it. The engine could attach to the neighboring ship, causing the overconnection handler to disconnect it again. Both operations raise on_train_created, so the cycle repeated recursively.

## This fix

This change leaves a lone engine disconnected when it is already pending removal:

* During construction-robot removal, the engine remains marked for deconstruction.
* Delayed player mining is identified by the existing player and undo_index queue fields

Ordinary disconnected engines still use the existing reconnection behavior

## Testing

Manually tested with Factorio 2.1.14 (confirmed crashing in the test scenario before, fixed after)